### PR TITLE
Use assets images for lever illustrations

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,14 +73,7 @@
       <article id="gmb" class="mt-12 md:mt-16 grid md:grid-cols-2 gap-8 items-center">
         <div class="order-1 md:order-1 reveal">
           <div class="aspect-[4/3] rounded-2xl border bg-white p-6 flex items-center justify-center">
-            <svg viewBox="0 0 400 300" class="w-full h-full">
-              <rect x="20" y="20" width="360" height="260" rx="16" fill="#F8FAFC" stroke="#E2E8F0"/>
-              <rect x="40" y="50" width="240" height="24" rx="6" fill="#DBEAFE"/>
-              <rect x="40" y="90" width="160" height="12" rx="6" fill="#E2E8F0"/>
-              <rect x="40" y="110" width="200" height="12" rx="6" fill="#E2E8F0"/>
-              <rect x="40" y="140" width="120" height="32" rx="8" fill="#93C5FD"/>
-              <circle cx="320" cy="110" r="36" fill="#BFDBFE"/>
-            </svg>
+            <img src="assets/img.gmb.png" alt="Illustration boost page Google" class="w-full h-full object-cover" />
           </div>
         </div>
         <div class="order-2 md:order-2 reveal">
@@ -115,14 +108,7 @@
         </div>
         <div class="order-2 reveal">
           <div class="aspect-[4/3] rounded-2xl border bg-white p-6 flex items-center justify-center">
-            <svg viewBox="0 0 400 300" class="w-full h-full">
-              <rect x="20" y="20" width="360" height="260" rx="16" fill="#F8FAFC" stroke="#E2E8F0"/>
-              <rect x="40" y="60" width="120" height="16" rx="6" fill="#E2E8F0"/>
-              <rect x="40" y="90" width="320" height="10" rx="5" fill="#E2E8F0"/>
-              <rect x="40" y="110" width="300" height="10" rx="5" fill="#E2E8F0"/>
-              <rect x="40" y="140" width="140" height="90" rx="10" fill="#DBEAFE"/>
-              <rect x="200" y="140" width="160" height="90" rx="10" fill="#BFDBFE"/>
-            </svg>
+            <img src="assets/img.rs.png" alt="Illustration réseaux sociaux" class="w-full h-full object-cover" />
           </div>
         </div>
       </article>
@@ -131,13 +117,7 @@
       <article id="site" class="mt-16 grid md:grid-cols-2 gap-8 items-center">
         <div class="order-1 md:order-1 reveal">
           <div class="aspect-[4/3] rounded-2xl border bg-white p-6 flex items-center justify-center">
-            <svg viewBox="0 0 400 300" class="w-full h-full">
-              <rect x="20" y="20" width="360" height="260" rx="16" fill="#F8FAFC" stroke="#E2E8F0"/>
-              <rect x="40" y="50" width="280" height="18" rx="6" fill="#E2E8F0"/>
-              <rect x="40" y="80" width="320" height="10" rx="5" fill="#E2E8F0"/>
-              <rect x="40" y="100" width="180" height="10" rx="5" fill="#E2E8F0"/>
-              <rect x="40" y="130" width="320" height="120" rx="10" fill="#DBEAFE"/>
-            </svg>
+            <img src="assets/img.website.png" alt="Illustration création de site internet" class="w-full h-full object-cover" />
           </div>
         </div>
         <div class="order-2 md:order-2 reveal">


### PR DESCRIPTION
## Summary
- Replace placeholder SVGs with PNGs from `assets` for each lever in the "Les 3 leviers" section

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b06c8181a4832fa116af91554a7311